### PR TITLE
solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ Make the `App` a class component with `pressedKey` in the `state`.
 - Implement a solution following the [React task guideline](https://github.com/mate-academy/react_task-guideline#react-tasks-guideline).
 - Use the [React TypeScript cheat sheet](https://mate-academy.github.io/fe-program/js/extra/react-typescript).
 - Open one more terminal and run tests with `npm test` to ensure your solution is correct.
-- Replace `<your_account>` with your Github username in the [DEMO LINK](https://<your_account>.github.io/react_keyboard/) and add it to the PR description.
+- Replace `<your_account>` with your Github username in the [DEMO LINK](https://StanislavKapytsia.github.io/react_keyboard/) and add it to the PR description.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,35 @@
 import React from 'react';
 
-export const App: React.FC = () => (
-  <div className="App">
-    <p className="App__message">The last pressed key is [Enter]</p>
-  </div>
-);
+type State = {
+  message: string;
+};
+
+export class App extends React.Component<State> {
+  state: State = {
+    message: '',
+  };
+
+  handleKeyUp = (e: KeyboardEvent) => {
+    this.setState({ message: `The last pressed key is [${e.key}]` });
+  };
+
+  componentDidMount(): void {
+    this.setState({ message: 'Nothing was pressed yet' });
+
+    document.addEventListener('keyup', this.handleKeyUp);
+  }
+
+  componentWillUnmount(): void {
+    window.removeEventListener('keyup', this.handleKeyUp);
+  }
+
+  render(): React.ReactNode {
+    const { message } = this.state;
+
+    return (
+      <div className="App">
+        <p className="App__message">{message}</p>
+      </div>
+    );
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ type State = {
 
 export class App extends React.Component<State> {
   state: State = {
-    message: '',
+    message: 'Nothing was pressed yet',
   };
 
   handleKeyUp = (e: KeyboardEvent) => {
@@ -14,8 +14,6 @@ export class App extends React.Component<State> {
   };
 
   componentDidMount(): void {
-    this.setState({ message: 'Nothing was pressed yet' });
-
     document.addEventListener('keyup', this.handleKeyUp);
   }
 


### PR DESCRIPTION
[DEMO LINK](https://StanislavKapytsia.github.io/react_keyboard/)

Make the `App` a class component with `pressedKey` in the `state`.

> Here is [the working version](https://mate-academy.github.io/react_keyboard/)

- before any key was pressed show the `Nothing was pressed yet` message;
- when a key is pressed show a `The last pressed key is [key]` message;
- use `componentDidMount` to add `keyup` handler:
    ```ts
    // DON'T import KeyboardEvent from React, because it is a regular event
    document.addEventListener('keyup', (event: KeyboardEvent) => {
      console.log(event.key);
    });
    ```
- use `removeEventListener` to remove a global handler in `componentWillUnmount`.